### PR TITLE
raised action versions to v1

### DIFF
--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create version releases
-        uses: climpr/semver-release@v0
+        uses: climpr/semver-release@v1
         with:
           update-type: ${{ github.event.inputs.update-type }}
           label: ${{ github.event.inputs.label }}


### PR DESCRIPTION
will remain a draft PR until internal testing succeeds

EDIT:
testing finished successfully.
A bug was present in AZ CLI 2.64. dropping the version in publishconfig.json to 2.63 allowed tests to succeed. 